### PR TITLE
Fix Makefile Lambda build and zip process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ all: $(LAMBDAS)
 
 $(LAMBDAS):
 	@echo "==> Building $@"
-	GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/$@/$@ ./$(shell echo $@)/.
+	GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/$@/bootstrap ./$(shell echo $@)/.
 	@echo "==> Zipping $@"
 	mkdir -p $(DIST_DIR)/$@
-	cd $(BIN_DIR)/$@ && zip -q ../../$(DIST_DIR)/$@/$@.zip $@
+	cd $(BIN_DIR)/$@ && zip -q ../../$(DIST_DIR)/$@/$@.zip bootstrap
 
 clean:
 	rm -rf $(BIN_DIR) $(DIST_DIR)


### PR DESCRIPTION
- Updated build output to use `bootstrap` as required by Lambda runtime
- Corrected zip command to include `bootstrap` instead of target name

## Description

Please include a summary of the change and which issue is fixed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test updates
- [ ] Other

## Checklist:

- [ ] My code follows the style guidelines
- [ ] I have performed a self-review
- [ ] I have added tests
- [ ] I have updated documentation
